### PR TITLE
feat: add interactive process type to MacOS

### DIFF
--- a/lib/src/app_auto_launcher_impl_macos.dart
+++ b/lib/src/app_auto_launcher_impl_macos.dart
@@ -33,6 +33,12 @@ class AppAutoLauncherImplMacOS extends AppAutoLauncher {
     </array>
     <key>RunAtLoad</key>
     <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>StandardErrorPath</key>
+    <string>/dev/null</string>
+    <key>StandardOutPath</key>
+    <string>/dev/null</string>
   </dict>
 </plist>
 ''';


### PR DESCRIPTION
Adds interactive process type to MacOS daemon for responsive user experience. Without this, the Flutter MacOS app seems to be a bit laggy/unresponsive (e.g. when animating) when launched at startup as by default the system throttles CPU and I/O usage for the app.

> Interactive jobs run with the same resource limitations as apps,
           that is to say, none. Interactive jobs are critical to maintaining
           a responsive user experience, and this key should only be used if
           an app's ability to be responsive depends on it, and cannot be made
           Adaptive.

Reference: https://www.manpagez.com/man/5/launchd.plist/.