### PR TITLE
fix(windows): detect startup approved register

### DIFF
--- a/lib/src/app_auto_launcher_impl_windows.dart
+++ b/lib/src/app_auto_launcher_impl_windows.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:launch_at_startup/src/app_auto_launcher.dart';
 import 'package:win32_registry/win32_registry.dart'
     if (dart.library.html) 'noop.dart';
@@ -19,10 +21,20 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
         desiredAccessRights: AccessRights.allAccess,
       );
 
+  RegistryKey get _startupApprovedRegKey => Registry.openPath(
+        RegistryHive.currentUser,
+        path:
+            r'Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run',
+        desiredAccessRights: AccessRights.allAccess,
+      );
+
+  static const int _startupApprovedRegKeyBytesLength = 12;
+
   @override
   Future<bool> isEnabled() async {
     String? value = _regKey.getValueAsString(appName);
-    return value == _registryValue;
+
+    return value == _registryValue && await _isStartupApproved();
   }
 
   @override
@@ -32,14 +44,46 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
       RegistryValueType.string,
       _registryValue,
     ));
+
+    final bytes = Uint8List(_startupApprovedRegKeyBytesLength);
+    // "2" as a first byte in this register means that the autostart is enabled
+    bytes[0] = 2;
+
+    _startupApprovedRegKey
+        .createValue(RegistryValue(appName, RegistryValueType.binary, bytes));
+
     return true;
   }
 
   @override
   Future<bool> disable() async {
-    if (await isEnabled()) {
-      _regKey.deleteValue(appName);
-    }
+    _removeValue(_regKey, appName);
+    _removeValue(_startupApprovedRegKey, appName);
     return true;
+  }
+
+  // https://renenyffenegger.ch/notes/Windows/registry/tree/HKEY_CURRENT_USER/Software/Microsoft/Windows/CurrentVersion/Explorer/StartupApproved/Run/index
+  // Odd first byte will prevent the app from autostarting
+  // Empty or any other value will allow the app to autostart
+  Future<bool> _isStartupApproved() async {
+    final value = _startupApprovedRegKey.getValue(appName);
+
+    if (value == null) {
+      return true;
+    }
+
+    final data = value.data;
+
+    if (data is! Uint8List || data.isEmpty) {
+      return true;
+    }
+
+    return data[0].isEven;
+  }
+
+  void _removeValue(RegistryKey key, String value) {
+    if (key.getValue(value) != null) {
+      key.deleteValue(value);
+    }
   }
 }


### PR DESCRIPTION
Currently, this plugin won't detect if the autostart is truly enabled. To do that correctly the [startup approved register](https://renenyffenegger.ch/notes/Windows/registry/tree/HKEY_CURRENT_USER/Software/Microsoft/Windows/CurrentVersion/Explorer/StartupApproved/Run/index) should also be checked. The odd first byte of this register will prevent the app from autostarting. Even byte or none will allow it. This register is used by the Windows Settings or any other app that can modify startup behaviour. Normally, when Windows Settings enables app to autostart, it will set the first byte to 0x0 or 0x2 and zero-out other 11 bytes.

To reproduce:
* open example app
* enable autostart in the app
* open Windows Settings -> Apps -> Startup
* disable autostart for the example app in Windows Settings
* reload the example app

The app will show that the autostart is enabled, but in fact, it is not.

With startup approved registry check it will show the true autostart state.