### PR TITLE
Update plugin to use win32_registry version 2.0.0

### DIFF
--- a/lib/src/app_auto_launcher_impl_windows.dart
+++ b/lib/src/app_auto_launcher_impl_windows.dart
@@ -48,9 +48,8 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
   @override
   Future<bool> enable() async {
     _regKey.createValue(
-      RegistryValue(
+      RegistryValue.string(
         appName,
-        RegistryValueType.string,
         _registryValue,
       ),
     );
@@ -60,7 +59,7 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
     bytes[0] = 2;
 
     _startupApprovedRegKey
-        .createValue(RegistryValue(appName, RegistryValueType.binary, bytes));
+        .createValue(RegistryValue.binary(appName, bytes));
 
     return true;
   }
@@ -76,15 +75,13 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
   // Odd first byte will prevent the app from autostarting
   // Empty or any other value will allow the app to autostart
   Future<bool> _isStartupApproved() async {
-    final value = _startupApprovedRegKey.getValue(appName);
+    final data = _startupApprovedRegKey.getBinaryValue(appName);
 
-    if (value == null) {
+    if (data == null) {
       return true;
     }
 
-    final data = value.data;
-
-    if (data is! Uint8List || data.isEmpty) {
+    if (data.isEmpty) {
       return true;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  win32_registry: ^1.1.3
+  win32_registry: ^2.0.0
 
 dev_dependencies:
   dependency_validator: ^3.0.0


### PR DESCRIPTION
Update the `launch_at_startup` plugin to use `win32_registry` version 2.0.0, which includes some breaking APIs changes: https://pub.dev/packages/win32_registry/changelog