### PR TITLE
Fix desktop entry file location for snap

### DIFF
--- a/lib/src/app_auto_launcher_impl_linux.dart
+++ b/lib/src/app_auto_launcher_impl_linux.dart
@@ -10,8 +10,11 @@ class AppAutoLauncherImplLinux extends AppAutoLauncher {
   });
 
   File get _desktopFile {
+    final homePath = Platform.environment.containsKey('SNAP')
+        ? Platform.environment['SNAP_REAL_HOME']
+        : Platform.environment['HOME'];
     return File(
-      '${Platform.environment['HOME']}/.config/autostart/$appName.desktop',
+      '$homePath/.config/autostart/$appName.desktop',
     );
   }
 


### PR DESCRIPTION
Snap packages run applications in a sandbox, which alters environment variables such as $HOME. Specifically, $HOME inside a snap points to a sandboxed path. This prevents autostart .desktop files from being written to the actual user configuration directory. 
Snap exposes the original user home directory via the `$SNAP_REAL_HOME` environment variable.
You can see the difference below:
```bash
[ryewell@arch] ➜ ~ snap run --shell brisk
[ryewell@arch ryewell]$ echo $HOME
/home/ryewell/snap/brisk/x1
[ryewell@arch ryewell]$ echo $SNAP_REAL_HOME
/home/ryewell
```

Fix:
This PR updates the logic to use `$SNAP_REAL_HOME` instead of `$HOME` for writing the desktop entry file if the app is running inside a snap sandbox.