### PR TITLE
fix(windows): handle missing registry key in isEnabled

### DIFF
--- a/lib/src/app_auto_launcher_impl_windows.dart
+++ b/lib/src/app_auto_launcher_impl_windows.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:launch_at_startup/src/app_auto_launcher.dart';
+import 'package:win32/win32.dart'
+    show ERROR_FILE_NOT_FOUND, HRESULT_FROM_WIN32, WindowsException;
 import 'package:win32_registry/win32_registry.dart'
     if (dart.library.html) 'noop.dart';
 
@@ -40,7 +42,17 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
 
   @override
   Future<bool> isEnabled() async {
-    String? value = _regKey.getStringValue(appName);
+    final String? value;
+    try {
+      value = _regKey.getStringValue(appName);
+    } on WindowsException catch (e) {
+      // The Run key may not exist yet on a fresh Windows install where no
+      // application has registered for startup, which means auto-start is
+      // not enabled. Rethrow anything else (for example access denied) so a
+      // genuine failure is not silently masked.
+      if (e.hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) rethrow;
+      return false;
+    }
 
     return value == _registryValue && await _isStartupApproved();
   }
@@ -74,7 +86,16 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
   // Odd first byte will prevent the app from autostarting
   // Empty or any other value will allow the app to autostart
   Future<bool> _isStartupApproved() async {
-    final value = _startupApprovedRegKey.getBinaryValue(appName);
+    final Uint8List? value;
+    try {
+      value = _startupApprovedRegKey.getBinaryValue(appName);
+    } on WindowsException catch (e) {
+      // The StartupApproved\Run key is created lazily and is often absent on
+      // a fresh install; a missing key is treated as approved by the null
+      // check below. Rethrow anything else so a genuine failure surfaces.
+      if (e.hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)) rethrow;
+      value = null;
+    }
 
     if (value == null) {
       return true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  win32: ^5.8.0
   win32_registry: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
`isEnabled()` reads the `Run` key via `Registry.openPath`, which throws a `WindowsException` (`ERROR_FILE_NOT_FOUND`) when the key doesn't exist instead of returning null. On a fresh Windows install where no app has registered a startup entry, that key (and the lazily created `StartupApproved\Run`) can be absent, so `isEnabled()` throws rather than reporting "off". Downstream this can abort an app's startup; in our case it aborted before `runApp()` and showed a blank window.

This guards both reads, treating a missing key as not-enabled / approved, consistent with the macOS and Linux implementations. The catch is scoped to `ERROR_FILE_NOT_FOUND` and rethrows anything else (e.g. access denied). Scoping it that way needs `WindowsException` / `HRESULT_FROM_WIN32`, which `win32_registry` doesn't re-export, so this declares `win32` (already a transitive dependency) directly.

Note: `enable()` opens the same keys and `createValue` doesn't create a missing parent, so it can still throw on a fresh install where `Run` is absent. Out of scope here; worth a separate fix.
