### PR TITLE
fix(windows): create missing registry keys in enable

### DIFF
--- a/lib/src/app_auto_launcher_impl_windows.dart
+++ b/lib/src/app_auto_launcher_impl_windows.dart
@@ -23,16 +23,21 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
 
   late String _registryValue;
 
+  static const String _runRegistryPath =
+      r'Software\Microsoft\Windows\CurrentVersion\Run';
+
+  static const String _startupApprovedRegistryPath =
+      r'Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run';
+
   RegistryKey get _regKey => Registry.openPath(
         RegistryHive.currentUser,
-        path: r'Software\Microsoft\Windows\CurrentVersion\Run',
+        path: _runRegistryPath,
         desiredAccessRights: AccessRights.allAccess,
       );
 
   RegistryKey get _startupApprovedRegKey => Registry.openPath(
         RegistryHive.currentUser,
-        path:
-            r'Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run',
+        path: _startupApprovedRegistryPath,
         desiredAccessRights: AccessRights.allAccess,
       );
 
@@ -47,7 +52,13 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
 
   @override
   Future<bool> enable() async {
-    _regKey.createValue(
+    // openPath (used on the read path) throws when a key does not exist, and
+    // createValue only writes to an already-open handle. On a fresh install
+    // the Run and StartupApproved\Run keys may not exist yet, so create them
+    // first. createKey creates any missing keys along the path and opens an
+    // existing key unchanged.
+    final regKey = Registry.currentUser.createKey(_runRegistryPath);
+    regKey.createValue(
       RegistryValue.string(
         appName,
         _registryValue,
@@ -58,7 +69,10 @@ class AppAutoLauncherImplWindows extends AppAutoLauncher {
     // "2" as a first byte in this register means that the autostart is enabled
     bytes[0] = 2;
 
-    _startupApprovedRegKey.createValue(RegistryValue.binary(appName, bytes));
+    final startupApprovedRegKey = Registry.currentUser.createKey(
+      _startupApprovedRegistryPath,
+    );
+    startupApprovedRegKey.createValue(RegistryValue.binary(appName, bytes));
 
     return true;
   }


### PR DESCRIPTION
`enable()` writes the autostart entries to the `Run` key and the lazily created `StartupApproved\Run` key, obtaining each via `Registry.openPath`. `openPath` throws when the key is absent, and `createValue` (`RegSetValueEx`) only writes to an already-open handle without creating the key, so on a fresh install where these keys don't exist yet `enable()` throws.

This switches `enable()` to `Registry.currentUser.createKey(...)`, which creates the key and any missing parents along the path before writing, and opens an existing key unchanged. The read path is untouched and existing users get the same written value as before; no new dependency. Counterpart to the `isEnabled()` fix in #42.
